### PR TITLE
Update ChunkFromFileChannelRequestEntity.java

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/common/network/ChunkFromFileChannelRequestEntity.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/network/ChunkFromFileChannelRequestEntity.java
@@ -103,7 +103,7 @@ public class ChunkFromFileChannelRequestEntity implements RequestEntity, Progres
             if (size == 0) {
                 size = -1;
             }
-            long maxCount = Math.min(mOffset + length - 1, mChannel.size());
+            long maxCount = Math.min(mOffset + length, mChannel.size());
             while (mChannel.position() < maxCount) {
                 readCount = mChannel.read(mBuffer);
                 try {


### PR DESCRIPTION
The -1 can cause the last byte to not end up in the request body (incomplete file), causing the server to time out because it expects the content length to be one byte larger. However, this one byte that isn't loaded and isn't sent is present in the file.

I was able to successfully test this and it fixed the error for me.